### PR TITLE
ColAndreas: plik z CA_RemoveBuilding oraz zmiany w README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ W g³ównym folderze znajdziesz kilka podstawowych plików/folderów. Poni¿ej znajdu
 * W pliku locale znajdziesz definie PLOCAL, które mo¿esz wykorzystaæ w kodzie.
 * w pliku ikony znajdziesz wszelkie ikonki, które s¹ dodane na mape (nie powi¹zuj¹c siê z ¿adnym innym systemem) 
 * W pliku pickupy znajdziesz wszelkie pickupy, które s¹ dodane na mapê (nie powi¹zuj¹c siê z ¿adnym innym systemem) 
+* W pliku colandreas_removebuildings znajdziesz funkcje "CA_RemoveBuilding" z pluginu ColAndreas, które s¹ odpowiednikiem "RemoveBuildingForPlayer". 
 
 ## Nazewnictwo
 Nazewnictwo, które powinniœmy stosowaæ do zmiennych jest przedstawione przy obiekty_zmienne. Nie zaleca siê odbiegania od tych norm i tworzenia miliona zmiennych. Przyk³ad poprawnie stworzonych obiektów na exampleObjects.
@@ -28,7 +29,8 @@ Aby poprawnie wgraæ obiekty na nasz serwer postêpuj zgodnie z poni¿szymi krokami
 5. Dodaj do pliku Nowe_Obiekty.pwn linijkê odpowiadaj¹c¹ za wczytanie twojego pliku .pwn, mo¿esz to zrobiæ u¿ywaj¹c "#include œcie¿ka/aaa.pwn". Nastêpnie umiejœæ linijkê wywo³uj¹c¹ Init i Connect (wywo³uj¹ siê one w 2 ró¿nych miejscach Gamemode). 
 * Dodajemy Init - poniewa¿ wykonuje siê on przy wczytaniu naszego Gamemode.
 * Dodajemy Connect - poniewa¿ wykonuje siê on przy ka¿dym zalogowaniu gracza na playerid
-* Upewnij siê, ¿e w ¿adnym z plików nie pozostawi³eœ b³êdnego kodowania (UTF-8 ETC), domyœlnie powinno to byæ (ANSI/WINDOWS 1250) 
+* Upewnij siê, ¿e w ¿adnym z plików nie pozostawi³eœ b³êdnego kodowania (UTF-8 ETC), domyœlnie powinno to byæ (ANSI/WINDOWS 1250)
+7. Je¿eli usuwa³eœ coœ wykorzystuj¹c "RemoveBuildingForPlayer", dodaj odpowiadaj¹c¹ mu funkcjê "CA_RemoveBuilding" z ColAndreas (https://github.com/Pottus/ColAndreas/wiki/Functions#ca_removebuilding) do pliku "colandreas_removebuildings.pwn".
 6. SprawdŸ wszystko za pomoc¹ specjalistycznego gamemode'a zamieszczonego w folderze "skrypt" 
 
 * UWAGA! Przy edycji jednego pliku, b¹dŸ dodaniu jednego interioru/exterioru od razu wrzucaj to na git'a stosuj¹c "git commit", jako opis ustawiaj to, co zmieni³eœ. Pozwoli nam to zaoszczêdziæ czasu przy Review. 

--- a/colandreas_removebuildings.pwn
+++ b/colandreas_removebuildings.pwn
@@ -1,0 +1,1166 @@
+ColAndreas_UsunBudynki()
+{
+    // gamemodes/obiekty/obiekty.pwn:
+    CA_RemoveBuilding(5464, 1902.4297, -1309.5391, 29.9141, 0.25);
+    CA_RemoveBuilding(3573, 1798.6484, -2057.9141, 14.9844, 0.25);
+    CA_RemoveBuilding(985, 2497.4063, 2777.0703, 11.5313, 0.25);
+    CA_RemoveBuilding(986, 2497.4063, 2769.1094, 11.5313, 0.25);
+    CA_RemoveBuilding(13024, -87.3047, -347.5000, 3.1719, 0.25);
+    CA_RemoveBuilding(12932, -117.9609, -337.4531, 3.6172, 0.25);
+    CA_RemoveBuilding(1297, 828.7656, -1390.1172, 15.6406, 0.25);
+    CA_RemoveBuilding(1462, 826.8516, -1385.6719, 12.5078, 0.25);
+    CA_RemoveBuilding(1307, 807.0313, -1363.7344, 12.7813, 0.25);
+    CA_RemoveBuilding(6003, 954.6875, -1305.7734, 30.1406, 0.25);
+    CA_RemoveBuilding(1266, 875.0469, -1383.4766, 28.1641, 0.25);
+    CA_RemoveBuilding(1297, 868.7656, -1390.1172, 15.6406, 0.25);
+    CA_RemoveBuilding(5817, 848.8594, -1370.4297, 17.7969, 0.25);
+    CA_RemoveBuilding(1440, 857.3750, -1381.1641, 13.0469, 0.25);
+    CA_RemoveBuilding(1365, 861.9844, -1380.4609, 13.6250, 0.25);
+    CA_RemoveBuilding(1260, 875.0469, -1383.4766, 28.1641, 0.25);
+    CA_RemoveBuilding(1462, 853.1953, -1359.7266, 12.5547, 0.25);
+    CA_RemoveBuilding(1635, 860.9141, -1359.8047, 16.0859, 0.25);
+    CA_RemoveBuilding(5818, 954.6875, -1305.7734, 30.1406, 0.25);
+    CA_RemoveBuilding(4239, 1407.9063, -1407.3984, 33.9844, 0.25);
+    CA_RemoveBuilding(691, 375.6094, -1285.7500, 43.3281, 0.25);
+    CA_RemoveBuilding(1529, 583.4609, -1502.1094, 16.0000, 0.25);
+    CA_RemoveBuilding(1215, 616.7656, -1495.7734, 14.3203, 0.25);
+    CA_RemoveBuilding(1215, 616.7656, -1492.0313, 14.3203, 0.25);
+    CA_RemoveBuilding(1215, 616.7656, -1488.4766, 14.3203, 0.25);
+    CA_RemoveBuilding(717, 1703.9922, -1150.1484, 23.0938, 0.25);
+    CA_RemoveBuilding(717, 1721.2344, -1150.1484, 23.0938, 0.25);
+    CA_RemoveBuilding(717, 1738.7813, -1150.1484, 23.0938, 0.25);
+    CA_RemoveBuilding(1412, 1917.3203, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1912.0547, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1906.7734, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1927.8516, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1922.5859, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1938.3906, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1933.1250, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1951.6094, -1821.1250, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1951.6094, -1815.8594, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1951.6094, -1810.5938, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1951.6094, -1805.3281, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1948.9844, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1943.6875, -1797.4219, 13.8125, 0.25);
+    CA_RemoveBuilding(1412, 1951.6094, -1800.0625, 13.8125, 0.25);
+    CA_RemoveBuilding(1226, 545.2109, -1523.2344, 17.5000, 0.25);
+    CA_RemoveBuilding(13374, 2241.4063, 21.4609, 33.1719, 0.25);
+    CA_RemoveBuilding(781, 2253.7734, -79.5313, 25.4922, 0.25);
+    CA_RemoveBuilding(781, 2259.3906, -79.4141, 25.4922, 0.25);
+    CA_RemoveBuilding(781, 2266.0859, -79.4141, 25.4922, 0.25);
+    CA_RemoveBuilding(11372, -2076.4375, -107.9297, 36.9688, 0.25);
+    CA_RemoveBuilding(11014, -2076.4375, -107.9297, 36.9688, 0.25);
+    CA_RemoveBuilding(3593, 2437.4844, -1644.1172, 12.9844, 0.25);
+    CA_RemoveBuilding(3682, 2673.0859, -2114.9063, 36.5469, 0.25);
+    CA_RemoveBuilding(3683, 2684.7656, -2088.0469, 20.1172, 0.25);
+    CA_RemoveBuilding(3289, 2484.4141, -2141.0078, 12.1875, 0.25);
+    CA_RemoveBuilding(3289, 2496.0625, -2141.0078, 12.1875, 0.25);
+    CA_RemoveBuilding(3289, 2679.2344, -2106.9766, 12.5391, 0.25);
+    CA_RemoveBuilding(3290, 2503.1250, -2073.3750, 12.4297, 0.25);
+    CA_RemoveBuilding(3290, 2515.4219, -2073.3750, 12.4063, 0.25);
+    CA_RemoveBuilding(3290, 2647.1016, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(3290, 2658.7188, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(3290, 2671.5000, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(3288, 2432.7266, -2133.0234, 12.4531, 0.25);
+    CA_RemoveBuilding(3686, 2448.1328, -2075.6328, 16.0469, 0.25);
+    CA_RemoveBuilding(3745, 2475.1016, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3745, 2482.0234, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3745, 2489.1016, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3745, 2496.0938, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3290, 2452.9609, -2129.0156, 25.2734, 0.25);
+    CA_RemoveBuilding(3756, 2484.2344, -2118.5547, 17.7031, 0.25);
+    CA_RemoveBuilding(3755, 2484.2344, -2118.5547, 17.7031, 0.25);
+    CA_RemoveBuilding(3779, 2631.9141, -2098.5781, 20.0078, 0.25);
+    CA_RemoveBuilding(3779, 2653.9375, -2092.3359, 20.0078, 0.25);
+    CA_RemoveBuilding(3257, 2432.7266, -2133.0234, 12.4531, 0.25);
+    CA_RemoveBuilding(3258, 2484.4141, -2141.0078, 12.1875, 0.25);
+    CA_RemoveBuilding(3258, 2496.0625, -2141.0078, 12.1875, 0.25);
+    CA_RemoveBuilding(3256, 2452.9609, -2129.0156, 25.2734, 0.25);
+    CA_RemoveBuilding(3567, 2446.8281, -2075.8438, 13.2578, 0.25);
+    CA_RemoveBuilding(3567, 2438.3594, -2075.8438, 13.2578, 0.25);
+    CA_RemoveBuilding(3627, 2448.1328, -2075.6328, 16.0469, 0.25);
+    CA_RemoveBuilding(3643, 2489.1016, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3643, 2482.0234, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3643, 2475.1016, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3643, 2496.0938, -2073.4766, 17.8203, 0.25);
+    CA_RemoveBuilding(3256, 2515.4219, -2073.3750, 12.4063, 0.25);
+    CA_RemoveBuilding(3256, 2503.1250, -2073.3750, 12.4297, 0.25);
+    CA_RemoveBuilding(3675, 2663.0547, -2121.6563, 30.6250, 0.25);
+    CA_RemoveBuilding(3675, 2665.7734, -2122.5078, 22.2813, 0.25);
+    CA_RemoveBuilding(3675, 2667.3594, -2120.7969, 19.4297, 0.25);
+    CA_RemoveBuilding(3675, 2669.3359, -2120.7969, 26.9141, 0.25);
+    CA_RemoveBuilding(3675, 2669.3359, -2120.7969, 13.2500, 0.25);
+    CA_RemoveBuilding(3675, 2679.4375, -2121.6563, 21.4297, 0.25);
+    CA_RemoveBuilding(3675, 2675.8594, -2121.6563, 25.6016, 0.25);
+    CA_RemoveBuilding(3675, 2684.2031, -2122.5078, 22.8906, 0.25);
+    CA_RemoveBuilding(3675, 2685.0547, -2119.7891, 14.5391, 0.25);
+    CA_RemoveBuilding(3675, 2685.1172, -2119.1016, 19.4297, 0.25);
+    CA_RemoveBuilding(3637, 2631.9141, -2098.5781, 20.0078, 0.25);
+    CA_RemoveBuilding(3637, 2653.9375, -2092.3359, 20.0078, 0.25);
+    CA_RemoveBuilding(3673, 2673.0859, -2114.9063, 36.5469, 0.25);
+    CA_RemoveBuilding(3258, 2679.2344, -2106.9766, 12.5391, 0.25);
+    CA_RemoveBuilding(3674, 2682.3203, -2114.5313, 39.0313, 0.25);
+    CA_RemoveBuilding(3636, 2684.7656, -2088.0469, 20.1172, 0.25);
+    CA_RemoveBuilding(3256, 2647.1016, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(3256, 2658.7188, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(3256, 2671.5000, -2073.3750, 12.4453, 0.25);
+    CA_RemoveBuilding(1689, 745.5859, -1381.1094, 25.8750, 0.25);
+    CA_RemoveBuilding(1689, 751.3359, -1368.0313, 25.8750, 0.25);
+    CA_RemoveBuilding(6516, 717.6875, -1357.2813, 18.0469, 0.25);
+    CA_RemoveBuilding(1415, 732.8516, -1332.8984, 12.6875, 0.25);
+    CA_RemoveBuilding(1439, 732.7266, -1341.7734, 12.6328, 0.25);
+
+    // gamemodes/obiekty/nowe/AmmuNationCommerce/ammuNationCommerce.pwn:
+    CA_RemoveBuilding(1283, 1670.8906, -1548.5313, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1670.3594, -1480.9375, 15.6250, 0.25);
+
+    // gamemodes/obiekty/nowe/basen/exterior.pwn:
+    CA_RemoveBuilding(4101, 1224.699, -1782.199, 29.898, 0.250);
+    CA_RemoveBuilding(4105, 1224.699, -1782.199, 29.898, 0.250);
+    CA_RemoveBuilding(1215, 1190.290, -1769.339, 13.109, 0.250);
+    CA_RemoveBuilding(1215, 1190.290, -1754.790, 13.109, 0.250);
+    CA_RemoveBuilding(1215, 1164.589, -1782.359, 13.109, 0.250);
+
+    // gamemodes/obiekty/nowe/BazaMechanikow/BazaMechanikow.pwn:
+    CA_RemoveBuilding(17772, 2870.2422, -1589.3906, 16.5625, 0.25);
+    CA_RemoveBuilding(1530, 2767.7813, -1621.1875, 11.2344, 0.25);
+    CA_RemoveBuilding(17904, 2769.2422, -1624.2266, 19.3203, 0.25);
+    CA_RemoveBuilding(1297, 2833.3047, -1593.1797, 13.3281, 0.25);
+    CA_RemoveBuilding(17550, 2870.2422, -1589.3906, 16.5625, 0.25);
+    CA_RemoveBuilding(620, 2809.4219, -1567.6328, 9.5469, 0.25);
+    CA_RemoveBuilding(620, 2809.2734, -1556.3125, 9.5469, 0.25);
+    CA_RemoveBuilding(1290, 2808.7109, -1562.2578, 15.9844, 0.25);
+    CA_RemoveBuilding(1294, 2848.3516, -1567.9531, 14.6797, 0.25);
+    CA_RemoveBuilding(1297, 2833.3047, -1593.1797, 13.3281, 0.25);
+
+    // gamemodes/obiekty/nowe/BialyDom/exterior.pwn:
+    CA_RemoveBuilding(951, 1103.880, -2011.969, 68.695, 0.250);
+    CA_RemoveBuilding(618, 1102.910, -1990.670, 61.062, 0.250);
+    CA_RemoveBuilding(691, 1208.650, -2000.069, 67.390, 0.250);
+    CA_RemoveBuilding(951, 1175.069, -1993.949, 68.718, 0.250);
+    CA_RemoveBuilding(618, 1165.130, -1994.119, 66.804, 0.250);
+    CA_RemoveBuilding(762, 1157.380, -1989.459, 67.734, 0.250);
+    CA_RemoveBuilding(661, 1148.699, -1992.979, 67.148, 0.250);
+    CA_RemoveBuilding(951, 1209.630, -2008.550, 68.648, 0.250);
+    CA_RemoveBuilding(673, 1127.239, -2080.780, 66.375, 0.250);
+    CA_RemoveBuilding(691, 1144.079, -2076.379, 68.101, 0.250);
+    CA_RemoveBuilding(691, 1175.609, -2079.469, 67.796, 0.250);
+    CA_RemoveBuilding(762, 1189.770, -2078.370, 70.742, 0.250);
+    CA_RemoveBuilding(691, 1207.609, -2079.080, 66.781, 0.250);
+    CA_RemoveBuilding(691, 1097.040, -2079.449, 61.546, 0.250);
+    CA_RemoveBuilding(951, 1104.160, -2060.770, 68.648, 0.250);
+    CA_RemoveBuilding(951, 1209.910, -2065.580, 68.695, 0.250);
+    CA_RemoveBuilding(1530, 1118.910, -2008.239, 75.023, 0.250);
+    CA_RemoveBuilding(4824, 1224.430, -2037.010, 62.929, 0.250);
+    CA_RemoveBuilding(4920, 1224.430, -2037.010, 62.929, 0.250);
+    CA_RemoveBuilding(1280, 1204.4922, -2039.8047, 68.3750, 0.25);
+
+    // gamemodes/obiekty/nowe/Bluberry/RadaMiasta/exterior.pwn:
+    // CA_RemoveBuilding(1308, 9.0234, 15.1563, -5.7109, 0.25);
+    // CA_RemoveBuilding(13189, 92.1250, -164.9141, 1.5859, 0.25);
+    // CA_RemoveBuilding(1449, 111.8672, -174.7891, 1.0625, 0.25);
+    // CA_RemoveBuilding(12943, 92.1250, -164.9141, 1.5859, 0.25);
+    // CA_RemoveBuilding(1438, 121.6953, -148.6016, 0.5469, 0.25);
+    // CA_RemoveBuilding(781, 220.6250, -134.5859, 0.4141, 0.25);
+    // CA_RemoveBuilding(781, 220.6953, -124.3203, 0.4141, 0.25);
+    // CA_RemoveBuilding(1688, 215.9375, -43.4922, 9.9531, 0.25);
+    // CA_RemoveBuilding(1687, 215.5938, -46.7344, 9.8594, 0.25);
+    // CA_RemoveBuilding(3335, 232.7031, 58.2344, 1.4922, 0.25);
+    // CA_RemoveBuilding(1412, 228.3125, -291.1797, 1.8047, 0.25);
+    // CA_RemoveBuilding(1412, 233.2188, -289.5547, 1.8047, 0.25);
+    // CA_RemoveBuilding(1685, 90.7813, -186.5625, 1.2891, 0.25);
+
+    // gamemodes/obiekty/nowe/BramyTelehamy/BramyTelehamy.pwn:
+    CA_RemoveBuilding(1231, -2661.550, -220.516, 6.062, 0.250);
+    CA_RemoveBuilding(1231, -2648.629, -220.570, 6.062, 0.250);
+    CA_RemoveBuilding(1231, -2804.520, -325.968, 8.921, 0.250);
+    CA_RemoveBuilding(1231, -2805.409, -333.796, 8.921, 0.250);
+
+    // gamemodes/obiekty/nowe/CentralBank/centralBank.pwn:
+    // CA_RemoveBuilding(4025, 1777.8359, -1773.9063, 12.5234, 0.25);
+    // CA_RemoveBuilding(4070, 1719.7422, -1770.7813, 23.4297, 0.25);
+    // CA_RemoveBuilding(1531, 1724.7344, -1741.5000, 14.1016, 0.25);
+    // CA_RemoveBuilding(4215, 1777.5547, -1775.0391, 36.7500, 0.25);
+    // CA_RemoveBuilding(3986, 1719.7422, -1770.7813, 23.4297, 0.25);
+    // CA_RemoveBuilding(4019, 1777.8359, -1773.9063, 12.5234, 0.25);
+
+    // gamemodes/obiekty/nowe/chinesefood/interior.pwn:
+    CA_RemoveBuilding(5729, 1034.810, -1285.569, 16.414, 0.250);
+    CA_RemoveBuilding(5946, 1034.810, -1285.569, 16.414, 0.250);
+    CA_RemoveBuilding(5785, 1037.050, -1286.150, 16.312, 0.250);
+
+    // gamemodes/obiekty/nowe/CinemaCar/CinemaCar.pwn:
+    CA_RemoveBuilding(1689, 650.835, -1338.239, 21.757, 0.250);
+    CA_RemoveBuilding(1689, 650.835, -1356.589, 21.757, 0.250);
+    CA_RemoveBuilding(1689, 650.835, -1377.660, 21.757, 0.250);
+    CA_RemoveBuilding(6490, 717.484, -1357.300, 20.296, 0.250);
+    CA_RemoveBuilding(6491, 717.484, -1357.300, 20.296, 0.250);
+    CA_RemoveBuilding(1689, 751.335, -1368.030, 25.875, 0.250);
+    CA_RemoveBuilding(1689, 745.585, -1381.109, 25.875, 0.250);
+    CA_RemoveBuilding(6516, 717.687, -1357.280, 18.046, 0.250);
+    CA_RemoveBuilding(1439, 732.726, -1341.770, 12.632, 0.250);
+    CA_RemoveBuilding(1415, 732.851, -1332.900, 12.687, 0.250);
+    CA_RemoveBuilding(1635, 677.195, -1328.880, 25.109, 0.250);
+    CA_RemoveBuilding(1635, 696.195, -1328.880, 25.109, 0.250);
+    CA_RemoveBuilding(1635, 702.234, -1328.880, 25.109, 0.250);
+    CA_RemoveBuilding(1635, 721.210, -1328.880, 25.109, 0.250);
+    CA_RemoveBuilding(1297, 792.085, -1358.119, 15.367, 0.250);
+
+    // gamemodes/obiekty/nowe/cjgirl/cjgirl.pwn:
+    CA_RemoveBuilding(13360, 870.539, -24.601, 64.117, 0.250);
+    CA_RemoveBuilding(12957, 861.523, -25.382, 62.851, 0.250);
+    CA_RemoveBuilding(12937, 873.992, -22.757, 65.101, 0.250);
+    CA_RemoveBuilding(3276, 877.210, -23.484, 63.054, 0.250);
+    CA_RemoveBuilding(3276, 884.328, -20.734, 63.093, 0.250);
+    CA_RemoveBuilding(3276, 891.453, -18.390, 63.054, 0.250);
+    CA_RemoveBuilding(3276, 894.453, -25.773, 63.148, 0.250);
+
+    // gamemodes/obiekty/nowe/ClintonDomLS/ClintonDomLS.pwn:
+    CA_RemoveBuilding(759, 701.187, -1646.819, 2.468, 0.250);
+    CA_RemoveBuilding(759, 701.187, -1649.000, 2.468, 0.250);
+    CA_RemoveBuilding(621, 700.437, -1653.089, 0.085, 0.250);
+    CA_RemoveBuilding(759, 701.179, -1652.010, 2.468, 0.250);
+    CA_RemoveBuilding(759, 701.179, -1654.319, 2.085, 0.250);
+    CA_RemoveBuilding(759, 701.187, -1656.339, 2.468, 0.250);
+    CA_RemoveBuilding(759, 701.187, -1658.520, 2.468, 0.250);
+    CA_RemoveBuilding(759, 701.179, -1661.530, 2.468, 0.250);
+    CA_RemoveBuilding(759, 701.179, -1663.839, 2.085, 0.250);
+    CA_RemoveBuilding(730, 694.445, -1658.479, 0.304, 0.250);
+    CA_RemoveBuilding(759, 696.226, -1655.270, 2.492, 0.250);
+    CA_RemoveBuilding(16378, 414.406, 2536.550, 18.898, 0.250);
+    CA_RemoveBuilding(759, 692.507, -1656.069, 2.492, 0.250);
+    CA_RemoveBuilding(762, 695.937, -1670.630, 3.742, 0.250);
+    CA_RemoveBuilding(762, 683.578, -1664.400, 3.742, 0.250);
+    CA_RemoveBuilding(762, 685.359, -1658.630, 3.742, 0.250);
+    CA_RemoveBuilding(759, 701.179, -1639.640, 2.085, 0.250);
+
+    // gamemodes/obiekty/nowe/coffeshopls/interior.pwn:
+    CA_RemoveBuilding(4006, 1394.359, -1620.660, 32.148, 0.250);
+    CA_RemoveBuilding(4055, 1394.359, -1620.660, 32.148, 0.250);
+
+    // gamemodes/obiekty/nowe/DMV/DMV_exterior.pwn:
+    CA_RemoveBuilding(1527, 1448.2344, -1755.8984, 14.5234, 0.25);
+    CA_RemoveBuilding(1283, 1388.3594, -1745.4453, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1441.8594, -1733.0078, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1403.3672, -1733.0078, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1414.4141, -1731.4297, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1430.1719, -1719.4688, 15.6250, 0.25);
+    CA_RemoveBuilding(1226, 1451.6250, -1727.6719, 16.4219, 0.25);
+    CA_RemoveBuilding(1226, 1467.9844, -1727.6719, 16.4219, 0.25);
+    CA_RemoveBuilding(1226, 1485.1719, -1727.6719, 16.4219, 0.25);
+    CA_RemoveBuilding(1226, 1505.1797, -1727.6719, 16.4219, 0.25);
+    CA_RemoveBuilding(1283, 1513.2344, -1732.9219, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1568.8828, -1745.4766, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1545.7656, -1731.6719, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1530.1172, -1717.0078, 15.6250, 0.25);
+    CA_RemoveBuilding(1283, 1582.6719, -1733.1328, 15.6250, 0.25);
+    CA_RemoveBuilding(4023, 1359.280, -1796.469, 24.343, 0.250);
+    CA_RemoveBuilding(4226, 1359.280, -1796.469, 24.343, 0.250);
+    CA_RemoveBuilding(1372, 1337.699, -1774.729, 12.664, 0.250);
+    CA_RemoveBuilding(1265, 1337.010, -1773.869, 13.000, 0.250);
+    CA_RemoveBuilding(1265, 1338.790, -1775.319, 12.968, 0.250);
+    CA_RemoveBuilding(1220, 1342.270, -1806.199, 12.929, 0.250);
+    CA_RemoveBuilding(1230, 1342.630, -1807.040, 12.976, 0.250);
+    CA_RemoveBuilding(1221, 1342.520, -1805.069, 12.984, 0.250);
+    CA_RemoveBuilding(1220, 1338.130, -1816.579, 12.929, 0.250);
+    CA_RemoveBuilding(1230, 1338.079, -1815.760, 12.976, 0.250);
+    CA_RemoveBuilding(1220, 1338.900, -1816.160, 12.929, 0.250);
+    CA_RemoveBuilding(1220, 1338.949, -1796.430, 12.929, 0.250);
+    CA_RemoveBuilding(1230, 1338.959, -1796.000, 13.664, 0.250);
+    CA_RemoveBuilding(1220, 1338.939, -1795.459, 12.929, 0.250);
+    CA_RemoveBuilding(1221, 1338.969, -1793.729, 12.984, 0.250);
+    CA_RemoveBuilding(1220, 1340.869, -1834.479, 12.929, 0.250);
+    CA_RemoveBuilding(1220, 1340.890, -1835.369, 12.929, 0.250);
+    CA_RemoveBuilding(1230, 1340.130, -1835.040, 12.976, 0.250);
+    CA_RemoveBuilding(1265, 1337.260, -1841.880, 13.000, 0.250);
+
+    // gamemodes/obiekty/nowe/DMV/DMV_exteriorpc.pwn:
+    CA_RemoveBuilding(1691, 2262.199, -69.429, 30.976, 0.250);
+    CA_RemoveBuilding(12959, 2261.419, -71.812, 25.578, 0.250);
+    CA_RemoveBuilding(13026, 2261.419, -71.812, 25.578, 0.250);
+    CA_RemoveBuilding(781, 2259.389, -79.414, 25.492, 0.250);
+    CA_RemoveBuilding(781, 2253.770, -79.531, 25.492, 0.250);
+    CA_RemoveBuilding(781, 2266.090, -79.414, 25.492, 0.250);
+
+    // gamemodes/obiekty/nowe/DomSejciak/DomSejciak.pwn:
+    CA_RemoveBuilding(3778, 553.3516, -1875.0000, 4.7891, 0.25);
+    CA_RemoveBuilding(3778, 289.2266, -1875.0000, 3.2031, 0.25);
+    CA_RemoveBuilding(3778, 245.5391, -1875.0000, 2.6875, 0.25);
+    CA_RemoveBuilding(3615, 553.3516, -1875.0000, 4.7891, 0.25);
+    CA_RemoveBuilding(3615, 245.5391, -1875.0000, 2.6875, 0.25);
+    CA_RemoveBuilding(3615, 289.2266, -1875.0000, 3.2031, 0.25);
+
+    // gamemodes/obiekty/nowe/ElPueblo/pueint.pwn:
+    CA_RemoveBuilding(5655, 2111.800, -1010.090, 55.148, 0.250);
+    CA_RemoveBuilding(5657, 2111.800, -1010.090, 55.148, 0.250);
+    CA_RemoveBuilding(5662, 2143.050, -1048.410, 48.648, 0.250);
+    CA_RemoveBuilding(5618, 2143.050, -1048.410, 48.648, 0.250);
+    CA_RemoveBuilding(5444, 2143.050, -1048.410, 48.648, 0.250);
+    CA_RemoveBuilding(5618, 2143.050, -1048.410, 48.648, 0.250);
+    CA_RemoveBuilding(1297, 2158.989, -1018.250, 65.015, 0.250);
+
+    // gamemodes/obiekty/nowe/FBI/parking.pwn:
+    CA_RemoveBuilding(1260, 591.726, -1508.930, 25.304, 0.250);
+    CA_RemoveBuilding(1215, 616.765, -1495.770, 14.320, 0.250);
+    CA_RemoveBuilding(1215, 616.765, -1492.030, 14.320, 0.250);
+    CA_RemoveBuilding(1215, 616.765, -1488.479, 14.320, 0.250);
+    CA_RemoveBuilding(6372, 599.093, -1435.400, 19.882, 0.250);
+    CA_RemoveBuilding(6520, 599.109, -1458.760, 45.062, 0.250);
+    CA_RemoveBuilding(1529, 583.460, -1502.109, 16.000, 0.250);
+    CA_RemoveBuilding(1260, 591.726, -1508.930, 25.304, 0.250);
+    CA_RemoveBuilding(1529, 583.460, -1502.109, 16.000, 0.250);
+
+    // gamemodes/obiekty/nowe/FirmaBudowlana/firmab.pwn:
+    CA_RemoveBuilding(6205, 954.273, -1720.800, 20.773, 0.250);
+    CA_RemoveBuilding(6208, 954.273, -1720.800, 20.773, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/bilboardy/bilb03dl.pwn:
+    // CA_RemoveBuilding(1260, 1581.119, -887.101, 58.500, 0.250);
+    // CA_RemoveBuilding(1266, 1581.119, -887.101, 58.500, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Dudson1895.pwn:
+    CA_RemoveBuilding(617, 1328.119, -668.296, 106.398, 0.250);
+    CA_RemoveBuilding(1691, 1354.209, -661.265, 113.405, 0.250);
+    CA_RemoveBuilding(1691, 1350.170, -650.554, 113.405, 0.250);
+    CA_RemoveBuilding(1688, 1348.050, -644.296, 113.991, 0.250);
+    CA_RemoveBuilding(1690, 1339.109, -637.109, 113.664, 0.250);
+    CA_RemoveBuilding(1687, 1327.560, -641.867, 113.813, 0.250);
+    CA_RemoveBuilding(1687, 1324.699, -642.945, 113.813, 0.250);
+    CA_RemoveBuilding(659, 1314.699, -624.054, 107.148, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Kamil1125.pwn:
+    CA_RemoveBuilding(710, 1429.969, -645.640, 108.305, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Konio1838.pwn:
+    CA_RemoveBuilding(710, 1073.910, -764.773, 120.164, 0.250);
+    CA_RemoveBuilding(710, 1089.709, -762.710, 120.625, 0.250);
+    CA_RemoveBuilding(672, 1095.589, -748.187, 105.476, 0.250);
+    CA_RemoveBuilding(672, 1077.790, -734.039, 105.351, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Miko1930.pwn:
+    CA_RemoveBuilding(621, 1034.199, -660.710, 118.484, 0.250);
+    CA_RemoveBuilding(710, 1055.680, -656.468, 134.358, 0.250);
+    CA_RemoveBuilding(672, 1031.989, -632.078, 119.960, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Pikus1929.pwn:
+    CA_RemoveBuilding(672, 1079.479, -665.546, 113.219, 0.250);
+    CA_RemoveBuilding(3604, 1079.969, -638.242, 115.015, 0.250);
+    CA_RemoveBuilding(3737, 1079.969, -638.242, 115.015, 0.250);
+    CA_RemoveBuilding(710, 1110.630, -680.507, 126.460, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/Verone1783.pwn:
+    CA_RemoveBuilding(1308, 2542.250, 109.203, 25.679, 0.250);
+    CA_RemoveBuilding(1408, 2539.830, 121.813, 26.031, 0.250);
+    CA_RemoveBuilding(1408, 2534.320, 121.813, 26.031, 0.250);
+    CA_RemoveBuilding(1408, 2523.689, 124.500, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2523.689, 130.007, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2523.689, 135.953, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2523.689, 142.483, 27.015, 0.250);
+    CA_RemoveBuilding(782, 2536.090, 122.789, 25.250, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/West326.pwn:
+    CA_RemoveBuilding(1688, 886.742, -666.414, 120.975, 0.250);
+    CA_RemoveBuilding(1688, 897.898, -669.570, 120.975, 0.250);
+    CA_RemoveBuilding(1691, 902.796, -657.992, 120.344, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/op_domow/WestLV1335.pwn:
+    CA_RemoveBuilding(986, 2497.409, 2769.110, 11.531, 0.250);
+    CA_RemoveBuilding(985, 2497.409, 2777.070, 11.531, 0.250);
+    CA_RemoveBuilding(7172, 2546.030, 2828.729, 11.539, 0.250);
+    CA_RemoveBuilding(960, 2570.729, 2829.770, 11.164, 0.250);
+    CA_RemoveBuilding(961, 2570.729, 2829.770, 11.171, 0.250);
+    CA_RemoveBuilding(960, 2608.800, 2806.909, 11.164, 0.250);
+    CA_RemoveBuilding(961, 2608.800, 2806.909, 11.171, 0.250);
+
+    // gamemodes/obiekty/nowe/Globalne/wadliwe_obiekty/wadliwe_obiekty.pwn:
+    CA_RemoveBuilding(1419, 2207.74, 108.484, 27, 0.250);
+
+    // gamemodes/obiekty/nowe/GlobalneLS/molo/molo.pwn:
+    //CA_RemoveBuilding(17910, 2916.7656, -1877.6484, 0.0703, 0.25);
+    //CA_RemoveBuilding(17953, 2916.7656, -1877.6484, 0.0703, 0.25);
+
+    // gamemodes/obiekty/nowe/GlobalneLS/Pomnik/pomnik.pwn:
+    CA_RemoveBuilding(748, 997.5547, -1858.2188, 11.9063, 0.25);
+    CA_RemoveBuilding(748, 999.6875, -1861.1016, 11.9063, 0.25);
+    CA_RemoveBuilding(712, 998.7266, -1859.5781, 21.0938, 0.25);
+
+    // gamemodes/obiekty/nowe/GlobalneLS/SkracaneZakrety/skracaneZakrety.pwn:
+    CA_RemoveBuilding(712, 1471.4063, -1666.1797, 22.2578, 0.25);
+
+    // gamemodes/obiekty/nowe/GlobalneLS/stacja_paliw_idle/sidle.pwn:
+    CA_RemoveBuilding(1226, 1951.930, -1756.520, 16.359, 0.250);
+    CA_RemoveBuilding(1226, 1955.660, -1793.089, 16.390, 0.250);
+    CA_RemoveBuilding(1412, 1938.390, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1933.130, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1927.849, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1922.589, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1917.319, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1912.050, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1906.770, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1943.689, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1948.979, -1797.420, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1951.609, -1800.060, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1951.609, -1805.329, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1951.609, -1810.589, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1951.609, -1815.859, 13.812, 0.250);
+    CA_RemoveBuilding(1412, 1951.609, -1821.130, 13.812, 0.250);
+    CA_RemoveBuilding(1676, 1941.660, -1778.449, 14.140, 0.250);
+    CA_RemoveBuilding(1676, 1941.660, -1774.310, 14.140, 0.250);
+    CA_RemoveBuilding(1676, 1941.660, -1771.339, 14.140, 0.250);
+    CA_RemoveBuilding(1676, 1941.660, -1767.290, 14.140, 0.250);
+
+    // gamemodes/obiekty/nowe/GlobalneLS/ZnakiUpiekszenia/znakiUpiekszenia.pwn:
+    CA_RemoveBuilding(1283, 1428.8984, -1577.1328, 15.6250, 0.25);
+    CA_RemoveBuilding(1226, 1525.3828, -1611.1563, 16.4219, 0.25);
+    CA_RemoveBuilding(3769, 1961.4453, -2216.1719, 14.9844, 0.25);
+    CA_RemoveBuilding(3625, 1961.4453, -2216.1719, 14.9844, 0.25);
+    CA_RemoveBuilding(1315, 2293.5000, -2086.3359, 15.8125, 0.25);
+    CA_RemoveBuilding(673, 2049.0547, -1733.7813, 12.0938, 0.25);
+    CA_RemoveBuilding(1283, 1852.2109, -1476.9609, 15.7109, 0.25);
+    CA_RemoveBuilding(1283, 1846.0469, -1449.8828, 15.9375, 0.25);
+    CA_RemoveBuilding(1283, 2176.4141, -1132.4453, 26.9688, 0.25);
+    CA_RemoveBuilding(1283, 2166.2734, -1119.2266, 27.5703, 0.25);
+    CA_RemoveBuilding(1283, 2218.2656, -1112.5234, 27.8359, 0.25);
+    CA_RemoveBuilding(1308, 2747.6094, -1625.9297, 12.3203, 0.25);
+
+    // gamemodes/obiekty/nowe/GlobalneLV/lv.pwn:
+    CA_RemoveBuilding(8145, 1493.9297, 751.0156, 20.9141, 0.25);
+    CA_RemoveBuilding(8132, 1436.5938, 673.2578, 12.4297, 0.25);
+    CA_RemoveBuilding(746, 1498.3672, 682.0313, 10.0859, 0.25);
+    CA_RemoveBuilding(8130, 1493.9297, 751.0156, 20.9141, 0.25);
+    CA_RemoveBuilding(779, 2523.5391, 65.0938, 25.4297, 0.25);
+    CA_RemoveBuilding(1446, 2523.8125, 57.6406, 26.2734, 0.25);
+    CA_RemoveBuilding(1446, 2523.8125, 62.3516, 26.2734, 0.25);
+
+    // gamemodes/obiekty/nowe/GlobalneLV/pustynialotnisko.pwn:
+    CA_RemoveBuilding(1224, 407.156, 2530.469, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 407.882, 2532.010, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 408.718, 2530.770, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 409.804, 2529.629, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 410.828, 2528.570, 16.156, 0.250);
+    CA_RemoveBuilding(3172, 400.117, 2543.570, 15.484, 0.250);
+    CA_RemoveBuilding(3345, 400.117, 2543.570, 15.484, 0.250);
+    CA_RemoveBuilding(3287, 255.983, 2549.330, 20.203, 0.250);
+    CA_RemoveBuilding(3296, 255.983, 2549.330, 20.203, 0.250);
+    CA_RemoveBuilding(16599, 231.281, 2545.800, 20.023, 0.250);
+    CA_RemoveBuilding(16598, 231.281, 2545.800, 20.023, 0.250);
+    CA_RemoveBuilding(1224, 316.367, 2531.610, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 316.265, 2533.080, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 316.164, 2534.649, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 316.351, 2545.139, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 315.664, 2550.060, 16.156, 0.250);
+    CA_RemoveBuilding(1224, 315.562, 2551.629, 16.156, 0.250);
+    CA_RemoveBuilding(16501, 429.984, 2546.520, 17.351, 0.250);
+    CA_RemoveBuilding(16098, 307.953, 2543.449, 20.398, 0.250);
+    CA_RemoveBuilding(16602, 307.953, 2543.449, 20.398, 0.250);
+
+    // gamemodes/obiekty/nowe/GSA/centralaGSA.pwn:
+    // CA_RemoveBuilding(4189, 1794.6172, -1576.7344, 17.7578, 0.25);
+    // CA_RemoveBuilding(700, 1799.1563, -1596.5391, 13.4453, 0.25);
+    // CA_RemoveBuilding(700, 1807.4688, -1590.4766, 13.4453, 0.25);
+
+    // gamemodes/obiekty/nowe/GunShop/gunshopls.pwn:
+    CA_RemoveBuilding(1617, 1792.010, -1149.099, 26.695, 0.250);
+    CA_RemoveBuilding(1617, 1789.500, -1149.030, 26.695, 0.250);
+    CA_RemoveBuilding(1265, 1788.060, -1148.449, 23.296, 0.250);
+    CA_RemoveBuilding(1227, 1786.209, -1148.300, 23.679, 0.250);
+    CA_RemoveBuilding(1264, 1784.410, -1148.390, 23.414, 0.250);
+    CA_RemoveBuilding(1265, 1830.469, -1141.939, 23.296, 0.250);
+    CA_RemoveBuilding(1227, 1830.619, -1143.819, 23.679, 0.250);
+    CA_RemoveBuilding(1227, 1830.569, -1147.380, 23.679, 0.250);
+    CA_RemoveBuilding(1227, 1830.569, -1113.930, 23.679, 0.250);
+    CA_RemoveBuilding(1264, 1829.829, -1112.390, 23.414, 0.250);
+    CA_RemoveBuilding(1265, 1830.839, -1112.209, 23.304, 0.250);
+    CA_RemoveBuilding(1227, 1800.449, -1148.300, 23.679, 0.250);
+    CA_RemoveBuilding(1617, 1831.439, -1140.599, 26.695, 0.250);
+    CA_RemoveBuilding(1617, 1831.439, -1146.430, 26.695, 0.250);
+    CA_RemoveBuilding(1215, 1789.489, -1142.839, 23.609, 0.250);
+    CA_RemoveBuilding(1617, 1831.439, -1114.589, 26.695, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom1/julia_dom1.pwn:
+    CA_RemoveBuilding(3555, 2148.709, -1324.000, 27.140, 0.250);
+    CA_RemoveBuilding(3563, 2148.709, -1324.000, 27.140, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom2/julia_dom2.pwn:
+    CA_RemoveBuilding(3555, 2150.040, -1281.130, 25.593, 0.250);
+    CA_RemoveBuilding(3563, 2150.040, -1281.130, 25.593, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom3/julia_dom3.pwn:
+    CA_RemoveBuilding(3580, 2126.780, -1325.729, 28.921, 0.250);
+    CA_RemoveBuilding(3772, 2126.780, -1325.729, 28.921, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom4/julia_dom4.pwn:
+    CA_RemoveBuilding(3557, 2132.250, -1276.949, 26.875, 0.250);
+    CA_RemoveBuilding(3560, 2132.250, -1276.949, 26.875, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom5/julia_dom5.pwn:
+    CA_RemoveBuilding(3557, 2100.899, -1324.989, 26.937, 0.250);
+    CA_RemoveBuilding(3560, 2100.899, -1324.989, 26.937, 0.250);
+
+    // gamemodes/obiekty/nowe/julia_dom6/julia_dom6.pwn:
+    CA_RemoveBuilding(3558, 2090.540, -1274.949, 27.445, 0.250);
+    CA_RemoveBuilding(3559, 2090.540, -1274.949, 27.445, 0.250);
+
+    // gamemodes/obiekty/nowe/KomisariatLS/parking_komisariatu.pwn:
+    CA_RemoveBuilding(1260, 1538.520, -1609.800, 19.843, 0.250);
+    CA_RemoveBuilding(1266, 1538.520, -1609.800, 19.843, 0.250);
+    CA_RemoveBuilding(1226, 1524.829, -1647.640, 16.421, 0.250);
+    CA_RemoveBuilding(1226, 1524.829, -1668.079, 16.421, 0.250);
+    CA_RemoveBuilding(1229, 1524.219, -1673.709, 14.109, 0.250);
+    CA_RemoveBuilding(1226, 1524.829, -1688.089, 16.421, 0.250);
+    CA_RemoveBuilding(712, 1508.449, -1668.739, 22.257, 0.250);
+    CA_RemoveBuilding(620, 1541.449, -1642.030, 13.046, 0.250);
+    CA_RemoveBuilding(620, 1547.569, -1661.030, 13.046, 0.250);
+    CA_RemoveBuilding(620, 1547.569, -1689.979, 13.046, 0.250);
+    CA_RemoveBuilding(620, 1541.449, -1709.640, 13.046, 0.250);
+    CA_RemoveBuilding(646, 1545.520, -1678.839, 14.000, 0.250);
+    CA_RemoveBuilding(646, 1545.560, -1672.219, 14.000, 0.250);
+    CA_RemoveBuilding(1260, 1538.520, -1609.800, 19.843, 0.250);
+    CA_RemoveBuilding(1266, 1538.520, -1609.800, 19.843, 0.250);
+    CA_RemoveBuilding(4090, 1602.910, -1608.160, 19.054, 0.250);
+    CA_RemoveBuilding(4096, 1602.910, -1608.160, 19.054, 0.250);
+
+    // gamemodes/obiekty/nowe/KorporacjaTransportowa/ktext.pwn:
+    CA_RemoveBuilding(3643, 2475.100, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3745, 2475.100, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3643, 2482.020, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3745, 2482.020, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3643, 2489.100, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3745, 2489.100, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3643, 2496.090, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3745, 2496.090, -2073.479, 17.820, 0.250);
+    CA_RemoveBuilding(3256, 2503.129, -2073.379, 12.429, 0.250);
+    CA_RemoveBuilding(3290, 2503.129, -2073.379, 12.429, 0.250);
+    CA_RemoveBuilding(3256, 2515.419, -2073.379, 12.406, 0.250);
+    CA_RemoveBuilding(3290, 2515.419, -2073.379, 12.406, 0.250);
+    CA_RemoveBuilding(3755, 2484.229, -2118.550, 17.703, 0.250);
+    CA_RemoveBuilding(3756, 2484.229, -2118.550, 17.703, 0.250);
+    CA_RemoveBuilding(1307, 2462.870, -2064.770, 12.320, 0.250);
+    CA_RemoveBuilding(3256, 2452.959, -2129.020, 25.273, 0.250);
+    CA_RemoveBuilding(3290, 2452.959, -2129.020, 25.273, 0.250);
+    CA_RemoveBuilding(3257, 2432.729, -2133.020, 12.453, 0.250);
+    CA_RemoveBuilding(3288, 2432.729, -2133.020, 12.453, 0.250);
+    CA_RemoveBuilding(3258, 2496.060, -2141.010, 12.187, 0.250);
+    CA_RemoveBuilding(3289, 2496.060, -2141.010, 12.187, 0.250);
+    CA_RemoveBuilding(3258, 2484.409, -2141.010, 12.187, 0.250);
+    CA_RemoveBuilding(3289, 2484.409, -2141.010, 12.187, 0.250);
+    CA_RemoveBuilding(3244, 2535.090, -2131.879, 12.992, 0.250);
+    CA_RemoveBuilding(3244, 2532.030, -2074.629, 12.992, 0.250);
+    CA_RemoveBuilding(3627, 2448.129, -2075.629, 16.046, 0.250);
+    CA_RemoveBuilding(3686, 2448.129, -2075.629, 16.046, 0.250);
+    CA_RemoveBuilding(3567, 2438.360, -2075.840, 13.257, 0.250);
+    CA_RemoveBuilding(3567, 2446.830, -2075.840, 13.257, 0.250);
+    CA_RemoveBuilding(1308, 2428.389, -2066.629, 12.679, 0.250);
+    CA_RemoveBuilding(1308, 1415.130, 363.414, 18.015, 0.250);
+    CA_RemoveBuilding(1410, 1393.030, 261.281, 19.179, 0.250);
+    CA_RemoveBuilding(5150, 2482.699, -2010.969, 23.601, 0.250);
+    CA_RemoveBuilding(5295, 2413.050, -2106.419, 23.054, 0.250);
+    CA_RemoveBuilding(5295, 2413.050, -2106.419, 23.054, 0.250);
+    CA_RemoveBuilding(5292, 2390.169, -2033.819, 23.828, 0.250);
+    CA_RemoveBuilding(5367, 2413.050, -2106.419, 23.054, 0.250);
+
+    // gamemodes/obiekty/nowe/KorporacjaTransportowa/ktint.pwn:
+    CA_RemoveBuilding(3755, 2484.229, -2118.550, 17.703, 0.250);
+    CA_RemoveBuilding(3756, 2484.229, -2118.550, 17.703, 0.250);
+
+    // gamemodes/obiekty/nowe/Lotniska/Lotniska.pwn:
+    CA_RemoveBuilding(4832, 1610.7969, -2285.8359, 52.7500, 0.25);
+    CA_RemoveBuilding(4948, 1610.7969, -2285.8359, 52.7500, 0.25);
+
+    // gamemodes/obiekty/nowe/LSMC/lsmc.pwn:
+    CA_RemoveBuilding(5935, 1120.1563, -1303.4531, 18.5703, 0.25);
+    CA_RemoveBuilding(1440, 1141.9844, -1346.1094, 13.2656, 0.25);
+    CA_RemoveBuilding(1440, 1148.6797, -1385.1875, 13.2656, 0.25);
+    CA_RemoveBuilding(1294, 1115.0781, -1285.3672, 17.0781, 0.25);
+    CA_RemoveBuilding(5737, 1120.1563, -1303.4531, 18.5703, 0.25);
+    CA_RemoveBuilding(1294, 1133.1094, -1276.7109, 17.0781, 0.25);
+    CA_RemoveBuilding(1283, 1140.8984, -1280.1172, 15.7109, 0.25);
+    CA_RemoveBuilding(1283, 1161.5859, -1281.3594, 15.7109, 0.25);
+    CA_RemoveBuilding(1283, 1150.5078, -1269.9375, 15.7109, 0.25);
+    CA_RemoveBuilding(1297, 1190.7734, -1320.8594, 15.9453, 0.25);
+    CA_RemoveBuilding(1297, 1190.770, -1320.859, 15.945, 0.250);
+    CA_RemoveBuilding(618, 1177.729, -1315.660, 13.296, 0.250);
+    CA_RemoveBuilding(620, 1184.810, -1303.150, 12.578, 0.250);
+    CA_RemoveBuilding(5737, 1120.160, -1303.449, 18.570, 0.250);
+    CA_RemoveBuilding(5935, 1120.160, -1303.449, 18.570, 0.250);
+    CA_RemoveBuilding(620, 1184.810, -1292.910, 12.578, 0.250);
+    CA_RemoveBuilding(1529, 1098.810, -1292.550, 17.140, 0.250);
+    CA_RemoveBuilding(620, 1184.010, -1343.270, 12.578, 0.250);
+    CA_RemoveBuilding(620, 1184.010, -1353.500, 12.578, 0.250);
+    CA_RemoveBuilding(617, 1178.599, -1332.069, 12.890, 0.250);
+    CA_RemoveBuilding(5788, 1080.979, -1305.520, 16.359, 0.250);
+    CA_RemoveBuilding(5787, 1090.050, -1310.530, 17.546, 0.250);
+    CA_RemoveBuilding(5936, 1090.050, -1310.530, 17.546, 0.250);
+    CA_RemoveBuilding(1294, 1115.079, -1285.369, 17.078, 0.250);
+    CA_RemoveBuilding(1297, 1190.770, -1350.410, 15.945, 0.250);
+    CA_RemoveBuilding(1440, 1141.979, -1346.109, 13.265, 0.250);
+    CA_RemoveBuilding(1440, 1148.680, -1385.189, 13.265, 0.250);
+
+    // gamemodes/obiekty/nowe/MelinaLasColinas/interior.pwn:
+    CA_RemoveBuilding(17928, 2337.159, -1179.800, 31.984, 0.250);
+    CA_RemoveBuilding(17593, 2337.159, -1179.800, 31.984, 0.250);
+    CA_RemoveBuilding(17552, 2337.159, -1179.800, 31.984, 0.250);
+    CA_RemoveBuilding(17593, 2337.159, -1179.800, 31.984, 0.250);
+
+    // gamemodes/obiekty/nowe/MonsterGarage/monsterint.pwn:
+    CA_RemoveBuilding(4848, 1931.000, -1871.390, 15.843, 0.250);
+    CA_RemoveBuilding(4976, 1931.000, -1871.390, 15.843, 0.250);
+
+    // gamemodes/obiekty/nowe/MountChiliad/mountChiliad.pwn:
+    CA_RemoveBuilding(785, -2823.9219, -1564.2734, 139.1250, 0.25);
+    CA_RemoveBuilding(785, -2828.4922, -1397.8672, 129.3906, 0.25);
+    CA_RemoveBuilding(785, -2795.5625, -1438.6953, 135.0547, 0.25);
+    CA_RemoveBuilding(785, -2856.3906, -1542.4922, 134.5391, 0.25);
+    CA_RemoveBuilding(785, -2810.2031, -1733.8594, 139.4766, 0.25);
+    CA_RemoveBuilding(785, -2827.6016, -1633.7656, 140.1875, 0.25);
+    CA_RemoveBuilding(785, -2803.5078, -1641.8281, 139.4766, 0.25);
+    CA_RemoveBuilding(785, -2867.5234, -1515.8359, 134.3047, 0.25);
+    CA_RemoveBuilding(785, -2836.5625, -1597.4063, 138.9844, 0.25);
+    CA_RemoveBuilding(785, -2826.5547, -1691.0156, 136.0078, 0.25);
+    CA_RemoveBuilding(785, -2833.6250, -1444.8672, 134.8281, 0.25);
+    CA_RemoveBuilding(785, -2820.0000, -1339.0625, 121.9922, 0.25);
+    CA_RemoveBuilding(785, -2837.3750, -1392.4688, 123.4141, 0.25);
+    CA_RemoveBuilding(785, -2792.0469, -1379.5625, 129.4453, 0.25);
+    CA_RemoveBuilding(785, -2800.0156, -1665.9375, 139.8047, 0.25);
+    CA_RemoveBuilding(785, -2796.0625, -1582.7656, 139.1250, 0.25);
+    CA_RemoveBuilding(785, -2847.3359, -1483.7344, 134.4219, 0.25);
+    CA_RemoveBuilding(784, -2806.3125, -1787.4531, 143.7578, 0.25);
+    CA_RemoveBuilding(784, -2793.4688, -1680.2656, 145.5391, 0.25);
+    CA_RemoveBuilding(784, -2834.7813, -1678.7266, 139.4766, 0.25);
+    CA_RemoveBuilding(784, -2800.7188, -1488.3906, 141.8359, 0.25);
+    CA_RemoveBuilding(784, -2851.2656, -1458.8438, 139.7969, 0.25);
+    CA_RemoveBuilding(791, -2867.5234, -1515.8359, 134.3047, 0.25);
+    CA_RemoveBuilding(791, -2856.3906, -1542.4922, 134.5391, 0.25);
+    CA_RemoveBuilding(791, -2836.5625, -1597.4063, 138.9844, 0.25);
+    CA_RemoveBuilding(791, -2847.3359, -1483.7344, 134.4219, 0.25);
+    CA_RemoveBuilding(791, -2810.2031, -1733.8594, 139.4766, 0.25);
+    CA_RemoveBuilding(694, -2806.3125, -1787.4531, 143.7578, 0.25);
+    CA_RemoveBuilding(694, -2834.7813, -1678.7266, 139.4766, 0.25);
+    CA_RemoveBuilding(791, -2827.6016, -1633.7656, 140.1875, 0.25);
+    CA_RemoveBuilding(791, -2826.5547, -1691.0156, 136.0078, 0.25);
+    CA_RemoveBuilding(791, -2823.9219, -1564.2734, 139.1250, 0.25);
+    CA_RemoveBuilding(18267, -2816.1797, -1524.2813, 139.7656, 0.25);
+    CA_RemoveBuilding(791, -2800.0156, -1665.9375, 139.8047, 0.25);
+    CA_RemoveBuilding(694, -2793.4688, -1680.2656, 145.5391, 0.25);
+    CA_RemoveBuilding(791, -2803.5078, -1641.8281, 139.4766, 0.25);
+    CA_RemoveBuilding(18230, -2811.0313, -1523.9141, 140.1250, 0.25);
+    CA_RemoveBuilding(791, -2796.0625, -1582.7656, 139.1250, 0.25);
+    CA_RemoveBuilding(694, -2800.7188, -1488.3906, 141.8359, 0.25);
+    CA_RemoveBuilding(694, -2851.2656, -1458.8438, 139.7969, 0.25);
+    CA_RemoveBuilding(791, -2833.6250, -1444.8672, 134.8281, 0.25);
+    CA_RemoveBuilding(791, -2795.5625, -1438.6953, 135.0547, 0.25);
+    CA_RemoveBuilding(791, -2837.3750, -1392.4688, 123.4141, 0.25);
+    CA_RemoveBuilding(791, -2828.4922, -1397.8672, 129.3906, 0.25);
+    CA_RemoveBuilding(791, -2792.0469, -1379.5625, 129.4453, 0.25);
+    CA_RemoveBuilding(791, -2820.0000, -1339.0625, 121.9922, 0.25);
+
+    // gamemodes/obiekty/nowe/NG/bazaNG.pwn:
+    //CA_RemoveBuilding(5156, 2838.0391, -2423.8828, 10.9609, 0.25);
+    //CA_RemoveBuilding(5159, 2838.0313, -2371.9531, 7.2969, 0.25);
+    //CA_RemoveBuilding(5160, 2829.9531, -2479.5703, 5.2656, 0.25);
+    //CA_RemoveBuilding(5161, 2838.0234, -2358.4766, 21.3125, 0.25);
+    //CA_RemoveBuilding(5162, 2838.0391, -2423.8828, 10.9609, 0.25);
+    //CA_RemoveBuilding(5163, 2838.0391, -2532.7734, 17.0234, 0.25);
+    //CA_RemoveBuilding(5164, 2838.1406, -2447.8438, 15.7266, 0.25);
+    //CA_RemoveBuilding(5165, 2838.0313, -2520.1875, 18.4141, 0.25);
+    //CA_RemoveBuilding(5166, 2829.9531, -2479.5703, 5.2656, 0.25);
+    //CA_RemoveBuilding(5167, 2838.0313, -2371.9531, 7.2969, 0.25);
+    //CA_RemoveBuilding(3689, 2685.3828, -2366.0547, 19.9531, 0.25);
+    //CA_RemoveBuilding(3689, 2430.5859, -2583.9453, 20.5234, 0.25);
+    //CA_RemoveBuilding(3707, 2716.2344, -2452.5938, 20.2031, 0.25);
+    //CA_RemoveBuilding(3707, 2720.3203, -2530.9141, 19.9766, 0.25);
+    //CA_RemoveBuilding(3707, 2480.8594, -2460.0547, 20.4922, 0.25);
+    //CA_RemoveBuilding(3707, 2539.1797, -2424.3594, 20.4922, 0.25);
+    //CA_RemoveBuilding(3690, 2685.3828, -2366.0547, 19.9531, 0.25);
+    //CA_RemoveBuilding(3690, 2430.5859, -2583.9453, 20.5234, 0.25);
+    //CA_RemoveBuilding(3688, 2387.8047, -2580.8672, 17.7891, 0.25);
+    //CA_RemoveBuilding(3688, 2450.8750, -2680.4531, 17.7891, 0.25);
+    //CA_RemoveBuilding(3687, 2503.5391, -2366.5078, 16.0469, 0.25);
+    //CA_RemoveBuilding(3687, 2475.2578, -2394.7891, 16.0469, 0.25);
+    //CA_RemoveBuilding(3687, 2450.5078, -2419.5391, 16.0469, 0.25);
+    //CA_RemoveBuilding(3686, 2464.3047, -2617.0156, 16.0469, 0.25);
+    //CA_RemoveBuilding(3710, 2788.1563, -2417.7891, 16.7266, 0.25);
+    //CA_RemoveBuilding(3710, 2788.1563, -2455.8828, 16.7266, 0.25);
+    //CA_RemoveBuilding(3710, 2788.1563, -2493.9844, 16.7266, 0.25);
+    //CA_RemoveBuilding(3709, 2511.9609, -2608.0156, 17.0703, 0.25);
+    //CA_RemoveBuilding(3709, 2511.9609, -2571.2422, 17.0703, 0.25);
+    //CA_RemoveBuilding(3709, 2511.9609, -2535.4531, 17.0703, 0.25);
+    //CA_RemoveBuilding(3709, 2660.4766, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(3709, 2639.5469, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(3709, 2618.8594, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(3708, 2720.3203, -2530.9141, 19.9766, 0.25);
+    //CA_RemoveBuilding(3708, 2716.2344, -2452.5938, 20.2031, 0.25);
+    //CA_RemoveBuilding(3708, 2480.8594, -2460.0547, 20.4922, 0.25);
+    //CA_RemoveBuilding(3708, 2539.1797, -2424.3594, 20.4922, 0.25);
+    //CA_RemoveBuilding(3710, 2415.4609, -2468.5781, 16.7266, 0.25);
+    //CA_RemoveBuilding(3744, 2771.0703, -2372.4453, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2789.2109, -2377.6250, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2774.7969, -2386.8516, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2771.0703, -2520.5469, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2774.7969, -2534.9531, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2437.2109, -2490.0938, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2399.4219, -2490.6797, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2391.8750, -2503.5078, 15.2188, 0.25);
+    //CA_RemoveBuilding(3744, 2551.5313, -2472.6953, 15.2188, 0.25);
+    //CA_RemoveBuilding(3709, 2544.2500, -2524.0938, 16.4453, 0.25);
+    //CA_RemoveBuilding(3709, 2544.2500, -2548.8125, 16.7031, 0.25);
+    //CA_RemoveBuilding(3746, 2814.2656, -2356.5703, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2814.2656, -2521.4922, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2568.4453, -2483.3906, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2563.1563, -2563.5781, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2531.7031, -2629.2266, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2519.8047, -2701.8750, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2381.1016, -2701.8750, 25.5156, 0.25);
+    //CA_RemoveBuilding(5325, 2488.9922, -2509.2578, 18.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2422.7031, -2411.9219, 25.5156, 0.25);
+    //CA_RemoveBuilding(3746, 2472.4453, -2362.9375, 25.5156, 0.25);
+    //CA_RemoveBuilding(3758, 2454.8281, -2702.9141, 3.0391, 0.25);
+    //CA_RemoveBuilding(3758, 2615.1094, -2464.6172, 3.0391, 0.25);
+    //CA_RemoveBuilding(3758, 2368.1641, -2523.8672, 3.0391, 0.25);
+    //CA_RemoveBuilding(3758, 2702.3984, -2324.2578, 3.0391, 0.25);
+    //CA_RemoveBuilding(5335, 2829.9531, -2479.5703, 5.2656, 0.25);
+    //CA_RemoveBuilding(5336, 2829.9531, -2479.5703, 5.2656, 0.25);
+    //CA_RemoveBuilding(3770, 2795.8281, -2394.2422, 14.1719, 0.25);
+    //CA_RemoveBuilding(3770, 2746.4063, -2453.4844, 14.0781, 0.25);
+    //CA_RemoveBuilding(3770, 2507.3672, -2640.0703, 14.0781, 0.25);
+    //CA_RemoveBuilding(3769, 2464.1250, -2571.6328, 15.1641, 0.25);
+    //CA_RemoveBuilding(3769, 2400.9063, -2577.3359, 15.1641, 0.25);
+    //CA_RemoveBuilding(5352, 2838.1953, -2488.6641, 29.3125, 0.25);
+    //CA_RemoveBuilding(3620, 2381.1016, -2701.8750, 25.5156, 0.25);
+    //CA_RemoveBuilding(1278, 2406.5469, -2695.0156, 26.6719, 0.25);
+    //CA_RemoveBuilding(1226, 2387.0547, -2667.7422, 16.4688, 0.25);
+    //CA_RemoveBuilding(1413, 2392.1172, -2653.5625, 13.9375, 0.25);
+    //CA_RemoveBuilding(1413, 2386.8438, -2653.5078, 13.9375, 0.25);
+    //CA_RemoveBuilding(1413, 2397.3984, -2653.6250, 13.9375, 0.25);
+    //CA_RemoveBuilding(1412, 2402.6719, -2653.6406, 13.9375, 0.25);
+    //CA_RemoveBuilding(1413, 2407.9453, -2653.6484, 13.9375, 0.25);
+    //CA_RemoveBuilding(1226, 2410.9766, -2632.8750, 16.4688, 0.25);
+    //CA_RemoveBuilding(3753, 2368.1641, -2523.8672, 3.0391, 0.25);
+    //CA_RemoveBuilding(3621, 2387.8047, -2580.8672, 17.7891, 0.25);
+    //CA_RemoveBuilding(3574, 2391.8750, -2503.5078, 15.2188, 0.25);
+    //CA_RemoveBuilding(3625, 2400.9063, -2577.3359, 15.1641, 0.25);
+    //CA_RemoveBuilding(1226, 2410.9766, -2562.8516, 16.4688, 0.25);
+    //CA_RemoveBuilding(1226, 2410.9766, -2535.2422, 16.4688, 0.25);
+    //CA_RemoveBuilding(1412, 2323.6563, -2353.5625, 13.7422, 0.25);
+    //CA_RemoveBuilding(1412, 2327.4141, -2357.2656, 13.7422, 0.25);
+    //CA_RemoveBuilding(1315, 2313.3047, -2333.0938, 15.8125, 0.25);
+    //CA_RemoveBuilding(1315, 2317.2109, -2348.6875, 15.8125, 0.25);
+    //CA_RemoveBuilding(1315, 2333.1484, -2344.5938, 15.8125, 0.25);
+    //CA_RemoveBuilding(1412, 2341.4766, -2343.1484, 13.8203, 0.25);
+    //CA_RemoveBuilding(1412, 2337.7188, -2339.4453, 13.8203, 0.25);
+    //CA_RemoveBuilding(1315, 2329.0859, -2328.6875, 15.8125, 0.25);
+    //CA_RemoveBuilding(3574, 2399.4219, -2490.6797, 15.2188, 0.25);
+    //CA_RemoveBuilding(3624, 2415.4609, -2468.5781, 16.7266, 0.25);
+    //CA_RemoveBuilding(3753, 2454.8281, -2702.9141, 3.0391, 0.25);
+    //CA_RemoveBuilding(3620, 2519.8047, -2701.8750, 25.5156, 0.25);
+    //CA_RemoveBuilding(3621, 2450.8750, -2680.4531, 17.7891, 0.25);
+    //CA_RemoveBuilding(1226, 2424.2969, -2658.9844, 16.2969, 0.25);
+    //CA_RemoveBuilding(1635, 2430.5781, -2653.9453, 23.7188, 0.25);
+    //CA_RemoveBuilding(1226, 2450.0156, -2632.7734, 16.3594, 0.25);
+    //CA_RemoveBuilding(1306, 2469.6016, -2645.3203, 19.8438, 0.25);
+    //CA_RemoveBuilding(3578, 2470.1406, -2628.2656, 13.1719, 0.25);
+    //CA_RemoveBuilding(3626, 2507.3672, -2640.0703, 14.0781, 0.25);
+    //CA_RemoveBuilding(3620, 2531.7031, -2629.2266, 25.5156, 0.25);
+    //CA_RemoveBuilding(3627, 2464.3047, -2617.0156, 16.0469, 0.25);
+    //CA_RemoveBuilding(1226, 2450.0156, -2604.9297, 16.3594, 0.25);
+    //CA_RemoveBuilding(1306, 2469.6016, -2579.9844, 19.8438, 0.25);
+    //CA_RemoveBuilding(3625, 2464.1250, -2571.6328, 15.1641, 0.25);
+    //CA_RemoveBuilding(1306, 2498.3438, -2612.6563, 19.8438, 0.25);
+    //CA_RemoveBuilding(1413, 2496.5547, -2585.1797, 13.9063, 0.25);
+    //CA_RemoveBuilding(1226, 2489.3516, -2566.2734, 16.2969, 0.25);
+    //CA_RemoveBuilding(1413, 2501.8359, -2585.2422, 13.9063, 0.25);
+    //CA_RemoveBuilding(1635, 2511.8359, -2622.6172, 17.3906, 0.25);
+    //CA_RemoveBuilding(3623, 2511.9609, -2608.0156, 17.0703, 0.25);
+    //CA_RemoveBuilding(3623, 2511.9609, -2571.2422, 17.0703, 0.25);
+    //CA_RemoveBuilding(1226, 2450.0156, -2563.2188, 16.3594, 0.25);
+    //CA_RemoveBuilding(1413, 2496.5547, -2557.3359, 13.9063, 0.25);
+    //CA_RemoveBuilding(1413, 2501.8359, -2557.3984, 13.9063, 0.25);
+    //CA_RemoveBuilding(1306, 2498.3438, -2547.3203, 19.8438, 0.25);
+    //CA_RemoveBuilding(1278, 2470.2734, -2539.0234, 26.6719, 0.25);
+    //CA_RemoveBuilding(1226, 2450.0156, -2535.5703, 16.3594, 0.25);
+    //CA_RemoveBuilding(1226, 2480.3281, -2536.4375, 16.3594, 0.25);
+    //CA_RemoveBuilding(3578, 2470.1406, -2530.5547, 13.1719, 0.25);
+    //CA_RemoveBuilding(1306, 2469.6016, -2514.6484, 19.8438, 0.25);
+    //CA_RemoveBuilding(1226, 2435.8203, -2512.4844, 16.4688, 0.25);
+    //CA_RemoveBuilding(3574, 2437.2109, -2490.0938, 15.2188, 0.25);
+    //CA_RemoveBuilding(1306, 2498.3438, -2481.9766, 19.8438, 0.25);
+    //CA_RemoveBuilding(1635, 2471.5859, -2494.0703, 15.0781, 0.25);
+    //CA_RemoveBuilding(1306, 2444.3281, -2435.0625, 19.8438, 0.25);
+    //CA_RemoveBuilding(1226, 2461.9141, -2444.3438, 16.3672, 0.25);
+    //CA_RemoveBuilding(3578, 2526.4297, -2561.3047, 13.1719, 0.25);
+    //CA_RemoveBuilding(3623, 2544.2500, -2548.8125, 16.7031, 0.25);
+    //CA_RemoveBuilding(3623, 2511.9609, -2535.4531, 17.0703, 0.25);
+    //CA_RemoveBuilding(3623, 2544.2500, -2524.0938, 16.4453, 0.25);
+    //CA_RemoveBuilding(1306, 2533.3906, -2514.1094, 19.8438, 0.25);
+    //CA_RemoveBuilding(1278, 2533.6172, -2461.6875, 26.6719, 0.25);
+    //CA_RemoveBuilding(3574, 2551.5313, -2472.6953, 15.2188, 0.25);
+    //CA_RemoveBuilding(3620, 2563.1563, -2563.5781, 25.5156, 0.25);
+    //CA_RemoveBuilding(3620, 2568.4453, -2483.3906, 25.5156, 0.25);
+    //CA_RemoveBuilding(3753, 2615.1094, -2464.6172, 3.0391, 0.25);
+    //CA_RemoveBuilding(1226, 2624.3281, -2452.1484, 16.4141, 0.25);
+    //CA_RemoveBuilding(1635, 2459.3359, -2427.8281, 16.7422, 0.25);
+    //CA_RemoveBuilding(3622, 2450.5078, -2419.5391, 16.0469, 0.25);
+    //CA_RemoveBuilding(3578, 2468.8594, -2413.5234, 13.1719, 0.25);
+    //CA_RemoveBuilding(3620, 2422.7031, -2411.9219, 25.5156, 0.25);
+    //CA_RemoveBuilding(1226, 2502.3281, -2404.0781, 16.3672, 0.25);
+    //CA_RemoveBuilding(1635, 2483.7188, -2403.3438, 16.7422, 0.25);
+    //CA_RemoveBuilding(1306, 2455.0703, -2399.0156, 19.8438, 0.25);
+    //CA_RemoveBuilding(3622, 2475.2578, -2394.7891, 16.0469, 0.25);
+    //CA_RemoveBuilding(1306, 2491.7031, -2383.3281, 19.8438, 0.25);
+    //CA_RemoveBuilding(3578, 2495.8438, -2386.9375, 13.1719, 0.25);
+    //CA_RemoveBuilding(3620, 2472.4453, -2362.9375, 25.5156, 0.25);
+    //CA_RemoveBuilding(3622, 2503.5391, -2366.5078, 16.0469, 0.25);
+    //CA_RemoveBuilding(3578, 2546.0469, -2396.5938, 13.1719, 0.25);
+    //CA_RemoveBuilding(1635, 2512.0078, -2375.0859, 16.7422, 0.25);
+    //CA_RemoveBuilding(1306, 2513.0000, -2339.3281, 19.8438, 0.25);
+    //CA_RemoveBuilding(3578, 2571.1641, -2421.1328, 13.1719, 0.25);
+    //CA_RemoveBuilding(3623, 2618.8594, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(1226, 2624.3281, -2409.5625, 16.4141, 0.25);
+    //CA_RemoveBuilding(1306, 2669.9063, -2518.6641, 19.8438, 0.25);
+    //CA_RemoveBuilding(1315, 2672.5938, -2506.8594, 15.8125, 0.25);
+    //CA_RemoveBuilding(1315, 2680.8594, -2493.0781, 15.8125, 0.25);
+    //CA_RemoveBuilding(1635, 2704.3672, -2487.8672, 20.5625, 0.25);
+    //CA_RemoveBuilding(1306, 2742.2656, -2481.5156, 19.8438, 0.25);
+    //CA_RemoveBuilding(1226, 2696.0234, -2474.8594, 16.4141, 0.25);
+    //CA_RemoveBuilding(1226, 2675.5703, -2466.8516, 16.4141, 0.25);
+    //CA_RemoveBuilding(5326, 2661.5156, -2465.1406, 20.1094, 0.25);
+    //CA_RemoveBuilding(1306, 2669.9063, -2447.2891, 19.8438, 0.25);
+    //CA_RemoveBuilding(1226, 2696.0234, -2446.6250, 16.4141, 0.25);
+    //CA_RemoveBuilding(3623, 2639.5469, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(3623, 2660.4766, -2429.2969, 17.0703, 0.25);
+    //CA_RemoveBuilding(1307, 2629.2109, -2419.6875, 12.2891, 0.25);
+    //CA_RemoveBuilding(1307, 2649.8984, -2419.6875, 12.2891, 0.25);
+    //CA_RemoveBuilding(1315, 2686.7578, -2416.6250, 15.8125, 0.25);
+    //CA_RemoveBuilding(1226, 2663.5078, -2409.5625, 16.4141, 0.25);
+    //CA_RemoveBuilding(1315, 2672.5938, -2408.2500, 15.8125, 0.25);
+    //CA_RemoveBuilding(1306, 2742.2656, -2416.5234, 19.8438, 0.25);
+    //CA_RemoveBuilding(3578, 2639.1953, -2392.8203, 13.1719, 0.25);
+    //CA_RemoveBuilding(3578, 2663.8359, -2392.8203, 13.1719, 0.25);
+    //CA_RemoveBuilding(1226, 2637.1719, -2385.8672, 16.4141, 0.25);
+    //CA_RemoveBuilding(1306, 2669.9063, -2394.5078, 19.8438, 0.25);
+    //CA_RemoveBuilding(1226, 2692.6797, -2387.4766, 16.4141, 0.25);
+    //CA_RemoveBuilding(1278, 2708.4063, -2391.5234, 26.7031, 0.25);
+    //CA_RemoveBuilding(3574, 2774.7969, -2534.9531, 15.2188, 0.25);
+    //CA_RemoveBuilding(3574, 2771.0703, -2520.5469, 15.2188, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2501.8359, 14.6953, 0.25);
+    //CA_RemoveBuilding(3624, 2788.1563, -2493.9844, 16.7266, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2486.9609, 14.6563, 0.25);
+    //CA_RemoveBuilding(3578, 2747.0078, -2480.2422, 13.1719, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2463.8203, 14.6328, 0.25);
+    //CA_RemoveBuilding(3624, 2788.1563, -2455.8828, 16.7266, 0.25);
+    //CA_RemoveBuilding(3626, 2746.4063, -2453.4844, 14.0781, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2448.4766, 14.6328, 0.25);
+    //CA_RemoveBuilding(3577, 2744.5703, -2436.1875, 13.3438, 0.25);
+    //CA_RemoveBuilding(3577, 2744.5703, -2427.3203, 13.3516, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2425.3516, 14.6328, 0.25);
+    //CA_RemoveBuilding(3574, 2774.7969, -2386.8516, 15.2188, 0.25);
+    //CA_RemoveBuilding(3574, 2771.0703, -2372.4453, 15.2188, 0.25);
+    //CA_RemoveBuilding(3761, 2783.7813, -2410.2109, 14.6719, 0.25);
+    //CA_RemoveBuilding(3624, 2788.1563, -2417.7891, 16.7266, 0.25);
+    //CA_RemoveBuilding(3574, 2789.2109, -2377.6250, 15.2188, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2501.8359, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2797.5156, -2486.8281, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2486.9609, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2463.8203, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2797.5156, -2448.3438, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2448.4766, 14.6328, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2425.3516, 14.6719, 0.25);
+    //CA_RemoveBuilding(3761, 2791.9531, -2410.2109, 14.6563, 0.25);
+    //CA_RemoveBuilding(3761, 2797.5156, -2410.0781, 14.6328, 0.25);
+    //CA_RemoveBuilding(3626, 2795.8281, -2394.2422, 14.1719, 0.25);
+    //CA_RemoveBuilding(3620, 2814.2656, -2521.4922, 25.5156, 0.25);
+    //CA_RemoveBuilding(5157, 2838.0391, -2532.7734, 17.0234, 0.25);
+    //CA_RemoveBuilding(5154, 2838.1406, -2447.8438, 15.7500, 0.25);
+    //CA_RemoveBuilding(3724, 2838.1953, -2488.6641, 29.3125, 0.25);
+    //CA_RemoveBuilding(3620, 2814.2656, -2356.5703, 25.5156, 0.25);
+    //CA_RemoveBuilding(5155, 2838.0234, -2358.4766, 21.3125, 0.25);
+    //CA_RemoveBuilding(3724, 2838.1953, -2407.1406, 29.3125, 0.25);
+    //CA_RemoveBuilding(3753, 2702.3984, -2324.2578, 3.0391, 0.25);
+    //CA_RemoveBuilding(1278, 2762.7578, -2333.3828, 26.7031, 0.25);
+    //CA_RemoveBuilding(5158, 2837.7734, -2334.4766, 11.9922, 0.25);
+
+    // gamemodes/obiekty/nowe/ObiektyDillimore/ObiektyDillimore.pwn:
+    CA_RemoveBuilding(1446, 741.6328, -517.7656, 16.3438, 0.25);
+    CA_RemoveBuilding(1446, 741.6328, -513.0703, 16.8359, 0.25);
+    CA_RemoveBuilding(1410, 731.8594, -595.0547, 16.0391, 0.25);
+    CA_RemoveBuilding(1410, 731.8594, -599.7266, 16.0000, 0.25);
+    CA_RemoveBuilding(1440, 642.7188, -511.0547, 15.8203, 0.25);
+    CA_RemoveBuilding(1410, 739.3750, -540.3438, 16.0391, 0.25);
+    CA_RemoveBuilding(1410, 734.7109, -540.3438, 16.0000, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -561.1094, 18.0938, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -565.8906, 18.1094, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -551.7891, 17.6875, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -556.4453, 17.9453, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -542.4844, 17.1719, 0.25);
+    CA_RemoveBuilding(1446, 756.6953, -547.1406, 17.4375, 0.25);
+    CA_RemoveBuilding(1410, 778.8750, -519.9844, 16.0000, 0.25);
+    CA_RemoveBuilding(1410, 774.2109, -519.9844, 16.0391, 0.25);
+    CA_RemoveBuilding(1410, 809.3672, -520.0234, 16.0625, 0.25);
+    CA_RemoveBuilding(1410, 814.0391, -520.0234, 16.0234, 0.25);
+    CA_RemoveBuilding(1410, 824.2188, -517.7813, 16.1250, 0.25);
+    CA_RemoveBuilding(1410, 824.2188, -513.1016, 16.4063, 0.25);
+    CA_RemoveBuilding(1410, 824.2188, -508.4219, 16.6484, 0.25);
+    CA_RemoveBuilding(1410, 824.2188, -503.7422, 16.8672, 0.25);
+    CA_RemoveBuilding(1503, 638.8359, -517.4766, 15.5469, 0.25);
+    CA_RemoveBuilding(1535, 245.2891, 61.9063, 1002.6328, 0.25);
+    CA_RemoveBuilding(1535, 248.3125, 61.9375, 1002.6328, 0.25);
+    CA_RemoveBuilding(14843, 266.3516, 81.1953, 1001.2813, 0.25);
+    CA_RemoveBuilding(2610, 236.3594, 70.7188, 1004.8984, 0.25);
+    CA_RemoveBuilding(2610, 237.3047, 70.7188, 1004.8984, 0.25);
+    CA_RemoveBuilding(2605, 232.1172, 65.0625, 1004.4609, 0.25);
+
+    // gamemodes/obiekty/nowe/opBeryl/opBeryl.pwn:
+    CA_RemoveBuilding(1410, 2206.760, 76.531, 26.953, 0.250);
+    CA_RemoveBuilding(1410, 2211.479, 76.531, 26.468, 0.250);
+    CA_RemoveBuilding(1410, 2213.780, 74.195, 26.132, 0.250);
+    CA_RemoveBuilding(1410, 2213.780, 66.945, 26.132, 0.250);
+    CA_RemoveBuilding(1410, 2213.780, 62.148, 26.132, 0.250);
+    CA_RemoveBuilding(779, 2210.040, 68.507, 25.789, 0.250);
+
+    // gamemodes/obiekty/nowe/opCzolgista/opCzolgista.pwn:
+    CA_RemoveBuilding(1408, 2333.800, 190.671, 26.046, 0.250);
+    CA_RemoveBuilding(3408, 2333.860, 193.742, 25.445, 0.250);
+    CA_RemoveBuilding(1408, 2331.000, 193.578, 26.507, 0.250);
+    CA_RemoveBuilding(1408, 2333.800, 184.304, 26.046, 0.250);
+    CA_RemoveBuilding(1408, 2333.800, 178.804, 26.046, 0.250);
+    CA_RemoveBuilding(1408, 2331.000, 176.695, 26.296, 0.250);
+
+    // gamemodes/obiekty/nowe/opDaniel/opDaniel.pwn:
+    CA_RemoveBuilding(717, 1322.270, -1155.910, 23.000, 0.250);
+
+    // gamemodes/obiekty/nowe/opdlaorg/StacjaMont/stam.pwn:
+    CA_RemoveBuilding(1450, 1394.040, 462.226, 19.757, 0.250);
+    CA_RemoveBuilding(1370, 1373.449, 469.968, 19.695, 0.250);
+    CA_RemoveBuilding(1370, 1373.170, 471.101, 19.695, 0.250);
+    CA_RemoveBuilding(1370, 1358.479, 483.656, 19.695, 0.250);
+
+    // gamemodes/obiekty/nowe/OPdlaRafalka/OPdlaRafalka.pwn:
+    CA_RemoveBuilding(647, -2557.159, 2240.699, 4.757, 0.250);
+    CA_RemoveBuilding(647, -2550.100, 2236.810, 4.390, 0.250);
+    CA_RemoveBuilding(647, -2546.979, 2243.879, 5.054, 0.250);
+    CA_RemoveBuilding(715, -2568.100, 2245.179, 11.945, 0.250);
+    CA_RemoveBuilding(647, -2546.870, 2269.810, 5.093, 0.250);
+
+    // gamemodes/obiekty/nowe/opFuBu/opFuBu.pwn:
+    CA_RemoveBuilding(762, 2261.649, -1624.800, 16.734, 0.250);
+
+    // gamemodes/obiekty/nowe/opJeffMatson/opJeffMatson.pwn:
+    CA_RemoveBuilding(1408, 2256.629, 154.382, 26.234, 0.250);
+    CA_RemoveBuilding(1408, 2256.629, 159.867, 26.671, 0.250);
+    CA_RemoveBuilding(1408, 2261.350, 159.897, 26.671, 0.250);
+    CA_RemoveBuilding(1408, 2261.350, 154.414, 26.234, 0.250);
+    CA_RemoveBuilding(1408, 2264.110, 151.835, 26.039, 0.250);
+    CA_RemoveBuilding(779, 2264.560, 157.781, 25.726, 0.250);
+
+    // gamemodes/obiekty/nowe/opLuizPuccinii/opLuizPuccinii.pwn:
+    CA_RemoveBuilding(1226, 1681.969, -2108.300, 16.390, 0.250);
+    CA_RemoveBuilding(620, 1682.140, -2102.350, 11.781, 0.250);
+
+    // gamemodes/obiekty/nowe/opPeter/opPeter.pwn:
+    CA_RemoveBuilding(780, 2210.050, -33.554, 25.640, 0.250);
+    CA_RemoveBuilding(1408, 2213.739, -34.421, 26.039, 0.250);
+    CA_RemoveBuilding(1408, 2213.739, -29.015, 26.039, 0.250);
+    CA_RemoveBuilding(3407, 2213.439, -50.164, 25.476, 0.250);
+
+    // gamemodes/obiekty/nowe/opSelect/opSelect.pwn:
+    CA_RemoveBuilding(1221, 2222.879, -1229.420, 23.406, 0.250);
+    CA_RemoveBuilding(1221, 2225.469, -1231.140, 23.406, 0.250);
+    CA_RemoveBuilding(1224, 2224.840, -1229.589, 23.562, 0.250);
+    CA_RemoveBuilding(1221, 2227.360, -1230.180, 23.406, 0.250);
+
+    // gamemodes/obiekty/nowe/OPSzklany/OPSzklany.pwn:
+    CA_RemoveBuilding(1408, 950.703, -696.671, 121.773, 0.250);
+    CA_RemoveBuilding(1408, 955.445, -693.632, 121.789, 0.250);
+    CA_RemoveBuilding(1409, 948.007, -698.789, 121.319, 0.250);
+    CA_RemoveBuilding(1409, 948.492, -699.742, 121.296, 0.250);
+    CA_RemoveBuilding(1408, 949.414, -700.609, 121.796, 0.250);
+    CA_RemoveBuilding(700, 956.742, -696.742, 121.203, 0.250);
+    CA_RemoveBuilding(700, 965.390, -713.390, 121.203, 0.250);
+
+    // gamemodes/obiekty/nowe/opTreylo/opTreylo.pwn:
+    CA_RemoveBuilding(781, 2211.689, -84.648, 25.578, 0.250);
+    CA_RemoveBuilding(3408, 2213.770, -83.960, 25.484, 0.250);
+    CA_RemoveBuilding(1408, 2211.199, -83.343, 26.140, 0.250);
+    CA_RemoveBuilding(1408, 2205.659, -83.343, 26.421, 0.250);
+    CA_RemoveBuilding(1408, 2200.030, -83.343, 26.718, 0.250);
+    CA_RemoveBuilding(1408, 2213.739, -92.710, 26.054, 0.250);
+    CA_RemoveBuilding(1408, 2213.739, -98.117, 26.054, 0.250);
+
+    // gamemodes/obiekty/nowe/opWashington/opWashington.pwn:
+    CA_RemoveBuilding(1408, 2285.399, 151.813, 26.015, 0.250);
+    CA_RemoveBuilding(1408, 2279.860, 151.813, 26.015, 0.250);
+    CA_RemoveBuilding(766, 2279.879, 155.171, 25.476, 0.250);
+    CA_RemoveBuilding(1408, 2274.330, 151.813, 26.015, 0.250);
+    CA_RemoveBuilding(1408, 2296.270, 156.983, 26.867, 0.250);
+    CA_RemoveBuilding(780, 2289.679, 176.063, 26.312, 0.250);
+
+    // gamemodes/obiekty/nowe/opWayneSkolds/opWayneSkolds.pwn:
+    CA_RemoveBuilding(691, 302.585, -1311.199, 51.867, 0.250);
+    CA_RemoveBuilding(669, 316.695, -1339.619, 52.343, 0.250);
+    CA_RemoveBuilding(669, 298.421, -1355.329, 52.093, 0.250);
+    CA_RemoveBuilding(669, 315.312, -1328.800, 52.179, 0.250);
+
+    // gamemodes/obiekty/nowe/opWilliam/opWilliam.pwn:
+    CA_RemoveBuilding(1468, 2443.790, -18.234, 26.718, 0.250);
+    CA_RemoveBuilding(1468, 2449.090, -18.234, 26.718, 0.250);
+    CA_RemoveBuilding(1468, 2427.850, -18.148, 27.703, 0.250);
+    CA_RemoveBuilding(1468, 2422.540, -18.148, 27.703, 0.250);
+    CA_RemoveBuilding(1468, 2417.229, -18.148, 27.703, 0.250);
+    CA_RemoveBuilding(1468, 2411.929, -18.148, 27.703, 0.250);
+    CA_RemoveBuilding(1468, 2406.629, -18.148, 27.703, 0.250);
+    CA_RemoveBuilding(3407, 2439.189, -18.210, 25.445, 0.250);
+    CA_RemoveBuilding(1468, 2443.790, -18.234, 26.718, 0.250);
+    CA_RemoveBuilding(1468, 2449.090, -18.234, 26.718, 0.250);
+    CA_RemoveBuilding(766, 2434.979, 3.507, 24.992, 0.250);
+
+    // gamemodes/obiekty/nowe/opWojtus/opWojtus.pwn:
+    CA_RemoveBuilding(1408, 2474.129, 124.694, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2474.129, 131.233, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2474.129, 137.171, 27.015, 0.250);
+    CA_RemoveBuilding(1408, 2474.129, 142.679, 27.015, 0.250);
+
+    // gamemodes/obiekty/nowe/ParkingObokSzpitala/parkingObokSzpitala.pwn:
+    //CA_RemoveBuilding(5929, 1230.8906, -1337.9844, 12.5391, 0.25);
+    //CA_RemoveBuilding(739, 1231.1406, -1341.8516, 12.7344, 0.25);
+    //CA_RemoveBuilding(739, 1231.1406, -1328.0938, 12.7344, 0.25);
+    //CA_RemoveBuilding(739, 1231.1406, -1356.2109, 12.7344, 0.25);
+    //CA_RemoveBuilding(1297, 1210.8047, -1367.3828, 15.7734, 0.25);
+    //CA_RemoveBuilding(620, 1222.6641, -1374.6094, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1222.6641, -1356.5547, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1240.9219, -1374.6094, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1240.9219, -1356.5547, 12.2969, 0.25);
+    //CA_RemoveBuilding(1297, 1210.8047, -1337.8359, 15.7734, 0.25);
+    //CA_RemoveBuilding(1297, 1210.8047, -1304.9688, 15.7734, 0.25);
+    //CA_RemoveBuilding(620, 1222.6641, -1335.0547, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1222.6641, -1317.7422, 12.2969, 0.25);
+    //CA_RemoveBuilding(5812, 1230.8906, -1337.9844, 12.5391, 0.25);
+    //CA_RemoveBuilding(620, 1240.9219, -1335.0547, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1240.9219, -1317.7422, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1222.6641, -1300.9219, 12.2969, 0.25);
+    //CA_RemoveBuilding(620, 1240.9219, -1300.9219, 12.2969, 0.25);
+    //CA_RemoveBuilding(1294, 1230.5078, -1285.3047, 17.0781, 0.25);
+
+    // gamemodes/obiekty/nowe/ParkSzpital/ParkSzpital.pwn:
+    CA_RemoveBuilding(620, 1222.660, -1335.050, 12.296, 0.250);
+    CA_RemoveBuilding(739, 1231.140, -1341.849, 12.734, 0.250);
+    CA_RemoveBuilding(620, 1240.920, -1356.550, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1240.920, -1374.609, 12.296, 0.250);
+    CA_RemoveBuilding(739, 1231.140, -1356.209, 12.734, 0.250);
+    CA_RemoveBuilding(620, 1222.660, -1356.550, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1240.920, -1335.050, 12.296, 0.250);
+    CA_RemoveBuilding(739, 1231.140, -1328.089, 12.734, 0.250);
+    CA_RemoveBuilding(620, 1240.920, -1317.739, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1240.920, -1300.920, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1222.660, -1300.920, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1222.660, -1317.739, 12.296, 0.250);
+    CA_RemoveBuilding(620, 1222.660, -1374.609, 12.296, 0.250);
+    CA_RemoveBuilding(5812, 1230.890, -1337.979, 12.539, 0.250);
+    CA_RemoveBuilding(5929, 1230.890, -1337.979, 12.539, 0.250);
+    CA_RemoveBuilding(1297, 1231.640, -1389.869, 15.671, 0.250);
+
+    // gamemodes/obiekty/nowe/Pizzernia idle/pizza.pwn:
+    CA_RemoveBuilding(16022, -313.992, 1742.819, 41.742, 0.250);
+    CA_RemoveBuilding(1408, 2099.850, -1793.979, 13.101, 0.250);
+    CA_RemoveBuilding(1408, 2102.659, -1791.329, 13.101, 0.250);
+    CA_RemoveBuilding(1432, 2102.060, -1793.140, 12.671, 0.250);
+    CA_RemoveBuilding(1432, 2101.629, -1798.170, 12.671, 0.250);
+    CA_RemoveBuilding(1432, 2103.689, -1795.910, 12.671, 0.250);
+    CA_RemoveBuilding(1432, 2103.959, -1800.560, 12.671, 0.250);
+    CA_RemoveBuilding(1408, 2099.860, -1799.420, 13.101, 0.250);
+    CA_RemoveBuilding(1432, 2104.020, -1812.420, 12.671, 0.250);
+    CA_RemoveBuilding(1432, 2103.409, -1817.300, 12.671, 0.250);
+    CA_RemoveBuilding(1432, 2101.989, -1814.709, 12.570, 0.250);
+    CA_RemoveBuilding(1408, 2099.850, -1813.910, 13.101, 0.250);
+    CA_RemoveBuilding(1408, 2102.600, -1822.079, 13.117, 0.250);
+    CA_RemoveBuilding(1408, 2099.860, -1819.359, 13.101, 0.250);
+    CA_RemoveBuilding(1432, 2102.129, -1819.949, 12.671, 0.250);
+    CA_RemoveBuilding(1308, 2128.310, -1826.839, 12.703, 0.250);
+    CA_RemoveBuilding(1308, 2091.159, -1826.839, 12.703, 0.250);
+    CA_RemoveBuilding(1226, 2085.750, -1809.699, 16.406, 0.250);
+    CA_RemoveBuilding(1226, 2114.719, -1785.180, 16.398, 0.250);
+    CA_RemoveBuilding(1308, 2128.310, -1786.709, 12.703, 0.250);
+    CA_RemoveBuilding(1259, 2128.229, -1780.709, 23.875, 0.250);
+    CA_RemoveBuilding(1268, 2128.229, -1780.709, 23.875, 0.250);
+    CA_RemoveBuilding(620, 2105.090, -1765.609, 10.804, 0.250);
+    CA_RemoveBuilding(712, 2100.810, -1764.380, 21.390, 0.250);
+
+    // gamemodes/obiekty/nowe/PowerGym/powergym.pwn:
+    CA_RemoveBuilding(5782, 897.664, -1346.699, 14.531, 0.250);
+    CA_RemoveBuilding(5948, 897.664, -1346.699, 14.531, 0.250);
+
+    // gamemodes/obiekty/nowe/przes/pub/pub.pwn:
+    CA_RemoveBuilding(621, 2272.1484, -1526.4141, 19.1953, 0.25);
+
+    // gamemodes/obiekty/nowe/rondo/rondo.pwn:
+    CA_RemoveBuilding(694, 2668.7656, -543.7422, 72.6328, 0.25);
+
+    // gamemodes/obiekty/nowe/sa_bahamas/sa_bahamas.pwn:
+    CA_RemoveBuilding(6192, 988.9063, -1487.9063, 24.5391, 0.25);
+    CA_RemoveBuilding(615, 929.0391, -1559.4609, 12.4766, 0.25);
+    CA_RemoveBuilding(1297, 922.1328, -1534.3125, 15.9375, 0.25);
+    CA_RemoveBuilding(8229, 1142.030, 1362.500, 12.484, 0.250);
+
+    // gamemodes/obiekty/nowe/Sad/interiorSCOSA.pwn:
+    CA_RemoveBuilding(620, 1330.6016, -1340.9844, 6.1094, 0.25);
+    CA_RemoveBuilding(620, 1326.6953, -1316.0078, 8.7266, 0.25);
+    CA_RemoveBuilding(620, 1327.5938, -1333.6719, 6.1094, 0.25);
+    CA_RemoveBuilding(620, 1332.0000, -1309.4297, 8.7266, 0.25);
+    CA_RemoveBuilding(620, 1321.5234, -1374.4297, 12.5859, 0.25);
+    CA_RemoveBuilding(620, 1292.0000, -1374.2969, 12.3672, 0.25);
+    CA_RemoveBuilding(620, 1300.5859, -1374.2969, 12.3672, 0.25);
+    CA_RemoveBuilding(620, 1329.4766, -1374.4297, 12.5859, 0.25);
+    CA_RemoveBuilding(1312, 1307.6172, -1394.4766, 16.5000, 0.25);
+    CA_RemoveBuilding(1297, 1309.8984, -1390.1172, 15.6406, 0.25);
+
+    // gamemodes/obiekty/nowe/SASD/exterior.pwn:
+    CA_RemoveBuilding(1446, 2366.060, -75.671, 28.250, 0.250);
+    CA_RemoveBuilding(1446, 2361.300, -75.671, 28.250, 0.250);
+    CA_RemoveBuilding(1446, 2370.840, -75.671, 28.250, 0.250);
+    CA_RemoveBuilding(1446, 2375.600, -75.671, 28.250, 0.250);
+    CA_RemoveBuilding(1446, 2356.520, -75.671, 28.250, 0.250);
+
+    // gamemodes/obiekty/nowe/stanowe/stanoweint.pwn:
+    CA_RemoveBuilding(16010, -569.617, 2593.530, 56.406, 0.250);
+    CA_RemoveBuilding(16612, -569.617, 2593.530, 56.406, 0.250);
+
+    // gamemodes/obiekty/nowe/USSS/usssint.pwn:
+    CA_RemoveBuilding(4058, 1529.500, -1470.530, 32.453, 0.250);
+    CA_RemoveBuilding(4062, 1529.500, -1470.530, 32.453, 0.250);
+
+    // gamemodes/obiekty/nowe/Vagos/Vagos.pwn:
+    CA_RemoveBuilding(5629, 2131.0859, -1029.3750, 50.1563, 0.25);
+
+    // gamemodes/obiekty/nowe/VeronalMall/VeronalMall.pwn:
+    CA_RemoveBuilding(6130, 1117.5859, -1490.0078, 32.7188, 0.25);
+    CA_RemoveBuilding(6255, 1117.5859, -1490.0078, 32.7188, 0.25);
+
+    // gamemodes/obiekty/nowe/WestEagle/eaglewest.pwn:
+    CA_RemoveBuilding(6322, 496.273, -1500.140, 16.664, 0.250);
+    CA_RemoveBuilding(6376, 496.273, -1500.140, 16.664, 0.250);
+    CA_RemoveBuilding(6332, 504.390, -1504.839, 29.000, 0.250);
+    CA_RemoveBuilding(6478, 504.390, -1504.839, 29.000, 0.250);
+
+    // gamemodes/obiekty/nowe/wps/interior.pwn:
+    CA_RemoveBuilding(1690, 1270.479, 240.460, 30.773, 0.250);
+    CA_RemoveBuilding(1688, 1265.689, 242.335, 31.093, 0.250);
+    CA_RemoveBuilding(13010, 1258.250, 245.516, 27.562, 0.250);
+    CA_RemoveBuilding(1687, 1253.989, 231.438, 26.343, 0.250);
+    CA_RemoveBuilding(1688, 1240.619, 232.188, 28.070, 0.250);
+    CA_RemoveBuilding(1687, 1248.630, 219.218, 26.343, 0.250);
+    CA_RemoveBuilding(1690, 1252.880, 206.539, 25.312, 0.250);
+    CA_RemoveBuilding(12905, 1251.589, 218.085, 18.468, 0.250);
+    CA_RemoveBuilding(13091, 1251.589, 218.085, 18.468, 0.250);
+    CA_RemoveBuilding(1688, 1251.010, 213.453, 23.046, 0.250);
+    CA_RemoveBuilding(12850, 1246.380, 231.367, 18.515, 0.250);
+    CA_RemoveBuilding(13227, 1246.380, 231.367, 18.515, 0.250);
+    CA_RemoveBuilding(1440, 1245.250, 245.233, 19.046, 0.250);
+    CA_RemoveBuilding(1440, 1247.040, 245.022, 19.046, 0.250);
+    CA_RemoveBuilding(1440, 1259.500, 250.203, 19.046, 0.250);
+    CA_RemoveBuilding(1294, 1278.199, 244.477, 23.007, 0.250);
+    CA_RemoveBuilding(1438, 1242.540, 216.742, 18.531, 0.250);
+    CA_RemoveBuilding(1438, 1240.589, 217.695, 18.531, 0.250);
+    CA_RemoveBuilding(1308, 1260.540, 251.492, 18.820, 0.250);
+    CA_RemoveBuilding(1294, 1248.150, 257.500, 23.007, 0.250);
+    CA_RemoveBuilding(1690, 1252.880, 206.539, 25.312, 0.250);
+    CA_RemoveBuilding(1351, 1277.500, 248.203, 18.476, 0.250);
+}


### PR DESCRIPTION
Dodano plik z wywołaniami CA_RemoveBuilding plugina ColAndreas. Funkcja ta odpowiada sampowemu RemoveBuildingForPlayer. Wywołania są opatrzone odpowiednimi komentarzami, by było wiadomo z którego pliku pochodzą (łatwość usunięcia przy wywaleniu obiektów).

Dodano zmiany w README związane z dodaniem rzeczonego pliku.